### PR TITLE
Bug fix/274 (#275)

### DIFF
--- a/src/test/java/com/arangodb/ArangoDatabaseTest.java
+++ b/src/test/java/com/arangodb/ArangoDatabaseTest.java
@@ -509,14 +509,14 @@ public class ArangoDatabaseTest extends BaseTest {
         public void getCollectionsExcludeSystem() {
                 try {
                         final CollectionsReadOptions options = new CollectionsReadOptions().excludeSystem(true);
-                        final Collection<CollectionEntity> systemCollections = db.getCollections(options);
+                        final Collection<CollectionEntity> nonSystemCollections = db.getCollections(options);
                         
-                        assertThat(systemCollections.size(), is(0));
+                        assertThat(nonSystemCollections.size(), is(0));
                         db.createCollection(COLLECTION_NAME + "1", null);
                         db.createCollection(COLLECTION_NAME + "2", null);
-                        final Collection<CollectionEntity> collections = db.getCollections(options);
-                        assertThat(collections.size(), is(2));
-                        assertThat(collections, is(notNullValue()));
+                        final Collection<CollectionEntity> newCollections = db.getCollections(options);
+                        assertThat(newCollections.size(), is(2));
+                        assertThat(newCollections, is(notNullValue()));
                 } catch (final ArangoDBException e) {
                   System.out.println(e.getErrorMessage());
                 } finally {

--- a/src/test/java/com/arangodb/ArangoGraphTest.java
+++ b/src/test/java/com/arangodb/ArangoGraphTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Iterator;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -288,4 +289,8 @@ public class ArangoGraphTest extends BaseTest {
 		assertThat(db.collection(vertexCollection).exists(), is(false));
 	}
 
+	@AfterClass
+	public static void shutdown() {
+		db.drop();
+	}
 }


### PR DESCRIPTION
* Added @AfterClass test fixture to drop database containing collections: edge_drop and vertex_drop that was causing ArangoDatabaseTest.getCollectionsExcludeSystem() to fail.

* Renamed variables for clarity.